### PR TITLE
Allow user of subnav.js to trigger a state refresh

### DIFF
--- a/js/components/subnav.js
+++ b/js/components/subnav.js
@@ -40,6 +40,7 @@ function refreshActiveState() {
 
 (function () {
   window.addEventListener('scroll', refreshActiveState);
+  window.addEventListener('shown.subnav', refreshActiveState);
 
   window.addEventListener('load', function () {
     refreshActiveState();
@@ -64,6 +65,7 @@ function refreshActiveState() {
       };
       jumpNav();
       window.addEventListener('scroll', jumpNav);
+      window.addEventListener('shown.subnav', jumpNav);
     }
 
     if (subnav) {

--- a/js/components/subnav.js
+++ b/js/components/subnav.js
@@ -32,13 +32,17 @@ function setActiveAnchor (index, elementArray) {
   }
 };
 
+function refreshActiveState() {
+  var activeAnchorIndex = getActiveAnchor(getAnchorPositions(getArrayFrom('.anchor')));
+  var anchorElements = getArrayFrom('[data-subnav-item]')
+  setActiveAnchor(activeAnchorIndex, anchorElements);
+};
+
 (function () {
-  window.addEventListener('scroll', function () {
-    setActiveAnchor(getActiveAnchor(getAnchorPositions(getArrayFrom('.anchor'))), getArrayFrom('[data-subnav-item]'))
-  });
+  window.addEventListener('scroll', refreshActiveState);
 
   window.addEventListener('load', function () {
-    setActiveAnchor(getActiveAnchor(getAnchorPositions(getArrayFrom('.anchor'))), getArrayFrom('[data-subnav-item]'));
+    refreshActiveState();
 
     var subnav = document.querySelector('.component.subnav');
     var topNavOffsetParam = subnav.getAttribute('data-top-nav-offset');


### PR DESCRIPTION
This allows a page including subnav.js to trigger an event to refresh the active anchor and positioning of the subnav.

This opens up use cases where the subnav is not shown upon page load, but shown later after load. Without this, in that case the position and active anchor calculations yield incorrect results because the positions of all hidden elements are 0.