### PR TITLE
Support multiple subnavs on the same page

### DIFF
--- a/css/components/_subnav.scss
+++ b/css/components/_subnav.scss
@@ -78,7 +78,7 @@ $subnav-padding-spacing: 16px 20px;
   }
 }
 
-#subnav-placeholder {
+.subnav-placeholder {
   @media screen and (max-width: $screen-xs-max) {
     display: none;
   }

--- a/js/components/subnav.js
+++ b/js/components/subnav.js
@@ -44,8 +44,10 @@ function refreshActiveState() {
 
   window.addEventListener('load', function () {
     refreshActiveState();
+    getArrayFrom('.component.subnav').map(setUpSubnav);
+  });
 
-    var subnav = document.querySelector('.component.subnav');
+  var setUpSubnav = function (subnav) {
     var topNavOffsetParam = subnav.getAttribute('data-top-nav-offset');
     var topNavOffset = topNavOffsetParam ? parseInt(topNavOffsetParam, 10) : 70;
 
@@ -53,7 +55,7 @@ function refreshActiveState() {
     if (subnav && subnav.classList.contains('dynamic-fixed')) {
 
       var jumpNav = function () {
-        var placeholder = document.getElementById('subnav-placeholder');
+        var placeholder = subnav.parentNode.classList.contains('subnav-placeholder') && subnav.parentNode
 
         placeholder.style.height = subnav.clientHeight + 'px';
 
@@ -75,5 +77,5 @@ function refreshActiveState() {
         }
       });
     }
-  });
+  };
 }());


### PR DESCRIPTION
This change enables the subnav component to work correctly when multiple subnav components are present on the same page. This allows AB testing of multiple versions of a subnav, as on the recent Product page redesign.

NOTE: This does include a potentially-breaking change for dependent products. The means of identifying the subnav placeholder element has been switched from an ID to a class (to allow multiple copies on the same page).

If your project markup, styles, or otherwise depends on `#subnav-placeholder`, you will instead need to refer to `.subnav-placeholder`.